### PR TITLE
Validar formulario antes de pasar al siguiente paso

### DIFF
--- a/src/views/Trabajadores.vue
+++ b/src/views/Trabajadores.vue
@@ -4,27 +4,26 @@
 
     <Container>
       <div class="col d-flex flex-column justify-content-between py-2 px-1 px-sm-5">
-        
-        <b-form @submit.prevent="registrarTrabajador">
-        <div id="#vista1" v-show="!ocultar">
-          <!-- Iconos para especificar la vista -->
-        <div class="d-flex justify-content-center align-items-center pb-3">
-          <span class="icon-user-plus rounded-circle p-2 border border-primary text-primary"></span>
-          <span class>---------</span>
-          <span class="icon-aid-kit rounded-circle p-2 border" icon="angry"></span>
-          <span class>---------</span>
-          <span class="icon-user-check rounded-circle p-2 border"></span>
-        </div>
-        <div v-if="error === false">
-          <div class="alert alert-success">Empleado fue registrado</div>
-        </div>
-        <div v-if="error === true">
-          <div class="alert alert-danger">Empleado no fue registrado</div>
-        </div>
-          <!-- Título del registro -->
-          <h4 class="px-sm-5 text-center text-sm-left">Información del trabajador:</h4>
-          <!-- Formulario -->
-          <div class="flex-grow-1 overflow-auto py-2 px-0 px-sm-5 my-2">
+        <b-form @submit.prevent="camposVacios" id="form-paso1">
+          <div id="#vista1" v-show="!ocultar">
+            <!-- Iconos para especificar la vista -->
+            <div class="d-flex justify-content-center align-items-center pb-3">
+              <span class="icon-user-plus rounded-circle p-2 border border-primary text-primary"></span>
+              <span class>---------</span>
+              <span class="icon-aid-kit rounded-circle p-2 border" icon="angry"></span>
+              <span class>---------</span>
+              <span class="icon-user-check rounded-circle p-2 border"></span>
+            </div>
+            <div v-if="error === false">
+              <div class="alert alert-success">Empleado fue registrado</div>
+            </div>
+            <div v-if="error === true">
+              <div class="alert alert-danger">Empleado no fue registrado</div>
+            </div>
+            <!-- Título del registro -->
+            <h4 class="px-sm-5 text-center text-sm-left">Información del trabajador:</h4>
+            <!-- Formulario -->
+            <div class="flex-grow-1 overflow-auto py-2 px-0 px-sm-5 my-2">
               <div class="form-group">
                 <input type="text" v-model="nombres" class="form-control" pattern="[A-Za-z_ ]{3,}" id="nombres" placeholder="Nombres" required/>
               </div>
@@ -32,99 +31,69 @@
                 <input type="text" v-model="apellidos" class="form-control" pattern="[A-Za-z_ ]{3,}" id="apellidos" placeholder="Apellidos" required/>
               </div>
               <div class="form-group">
-                <input
-                  type="text"
-                  v-model="direccion"
-                  class="form-control"
-                  id="direccion"
-                  placeholder="Dirección actual"
-                  required
-                />
-              </div>
-              <div class="form-group">
+                <input type="text" v-model="direccion" class="form-control" id="direccion" placeholder="Dirección actual" required />
+                </div>
+                <div class="form-group">
                 <input type="email" v-model="correo" class="form-control" id="correo" placeholder="Correo" required/>
-              </div>
+                </div>
               <div class="form-group">
                 <b-form-select v-model="tipoDocumento" :options="opcionesTipoDoc" required></b-form-select>
-              </div>
+                </div>
               <div class="form-group">
                 <input type="text" v-model="documento" class="form-control" id="documento" placeholder="Documento" required/>
-              </div>
-              <div class="form-group">
+                </div>
+                <div class="form-group">
                 <input type="text" v-model="telefono" class="form-control" id="telefono" placeholder="Teléfono" required/>
-              </div>
-              <div class="form-group">
+                </div>
+                <div class="form-group">
                 <input type="text" v-model="celular" class="form-control" id="celular" placeholder="Celular" />
-              </div>
+                </div>
               <div class="form-group">
                 <b-form-select v-model="nivelRiesgo" :options="opcionesRiesgo" required></b-form-select>
-              </div>
+                </div>
               <div class="form-group">
                 <label for="nacimiento">Fecha de nacimiento</label>
                 <input type="date" v-model="fechaNacimiento" class="form-control" id="nacimiento" min="1939-01-01" max="2000-12-29" required/>
-              </div>
-              <div class="form-group text-left">
-                <input
-                  type="text"
-                  v-model="telefonoFamiliar"
-                  class="form-control"
-                  id="telefonoFamiliar"
-                  placeholder="Teléfono de un familiar"
-                  required
-                />
-              </div>
+                </div>
+                <div class="form-group text-left">
+                <input type="text" v-model="telefonoFamiliar" class="form-control" id="telefonoFamiliar" placeholder="Teléfono de un familiar" required />
+                </div>
               <div class="form-check">
-                <input
-                  class="form-check-input"
-                  v-model="tipoTrabajador"
-                  type="checkbox"
-                  value="tipoTrabajador"
-                  id="tipoTrabajador"
-                />
-                <label
-                  class="form-check-label"
-                  for="tipoTrabajador"
-                >¿El trabajador se desempeña en el área de salud y seguridad en el trabajo?</label>
+                <input class="form-check-input" v-model="tipoTrabajador" type="checkbox" value="tipoTrabajador" id="tipoTrabajador" />
+                <label class="form-check-label" for="tipoTrabajador">¿El trabajador se desempeña en el área de salud y seguridad en el trabajo?</label>
+                </div>
+              <div v-if="mostrarCamposVacios">
+                <div class="alert alert-danger">Campos vacios</div>
               </div>
-            <div v-if="mostrarCamposVacios">
-              <div class="alert alert-danger">Campos vacios</div>
             </div>
+            <b-button type="submit" class="float-right" variant="primary">Siguiente</b-button>
           </div>
-          <b-button class="float-right" @click="camposVacios()" variant="primary">Siguiente</b-button>
-        </div>
+        </b-form>
 
         <!-- Seleccion de vacunas -->
-        <div id="#vista2" v-show="ocultar">
-
-        <!-- Título del registro -->
-        <h4 class="px-sm-5 pb-2 text-center text-sm-left">Listado de vacunas</h4>
-
-          <!-- Iconos para especificar la vista -->
-        <div class="d-flex justify-content-center align-items-center pb-3">
-          <span class="icon-user-plus rounded-circle p-2 border"></span>
-          <span class>---------</span>
-          <span class="icon-aid-kit rounded-circle p-2 border border-primary text-primary" icon="angry"></span>
-          <span class>---------</span>
-          <span class="icon-user-check rounded-circle p-2 border"></span>
-        </div>
-
-        <!-- Lista de vacunas -->
-        <div class="flex-grow-1 overflow-auto py-2 px-0 px-sm-5 my-2">
-            <b-form-group>
-              <b-form-checkbox-group
-              id="checkbox-group-1"
-              v-model="detallesVacunacion"
-              :options=[]
-              name="flavour-1"
-            ></b-form-checkbox-group>
-            </b-form-group>
-        </div>
-        </div>
-        <!-- Botón Atras -->
-        <b-button  class="float-left" @click="ocultar = !ocultar" variant="primary" v-show="ocultar">Atras</b-button>
-
-        <!-- Botón Registrar -->
-        <b-button  class="float-right" type="submit" variant="primary" v-if="ocultar">Registrar</b-button>
+        <b-form @submit.prevent="registrarTrabajador">
+          <div id="#vista2" v-show="ocultar">
+            <!-- Título del registro -->
+            <h4 class="px-sm-5 pb-2 text-center text-sm-left">Listado de vacunas</h4>
+            <!-- Iconos para especificar la vista -->
+            <div class="d-flex justify-content-center align-items-center pb-3">
+              <span class="icon-user-plus rounded-circle p-2 border"></span>
+              <span class>---------</span>
+              <span class="icon-aid-kit rounded-circle p-2 border border-primary text-primary" icon="angry"></span>
+              <span class>---------</span>
+              <span class="icon-user-check rounded-circle p-2 border"></span>
+            </div>
+            <!-- Lista de vacunas -->
+            <div class="flex-grow-1 overflow-auto py-2 px-0 px-sm-5 my-2">
+              <!-- <b-form-group>
+                <b-form-checkbox-group id="checkbox-group-1" v-model="detallesVacunacion" :options=[] name="flavour-1"></b-form-checkbox-group>
+                </b-form-group> -->
+            </div>
+          </div>
+          <!-- Botón Atras -->
+          <b-button class="float-left" @click="ocultar = !ocultar" variant="primary" v-show="ocultar">Atras</b-button>
+          <!-- Botón Registrar -->
+          <b-button class="float-right" type="submit" variant="primary" v-if="ocultar">Registrar</b-button>
         </b-form>
       </div>
     </Container>
@@ -135,7 +104,6 @@
 import Container from '@/components/Container.vue'
 import Header from '@/components/Header.vue'
 import axios from 'axios'
-import router from '../router'
 
 export default {
   name: 'Trabajadores',
@@ -197,7 +165,7 @@ export default {
 
         console.log(res.data)
       }).catch(err => {
-        
+
         console.log(err)
       });
       this.nombres= '';
@@ -217,10 +185,10 @@ export default {
       this.mostrarCamposVacios=false;
     },
     camposVacios () {
-      if([this.nombres, this.apellidos, this.direccion, this.correo, this.tipoDocumento, this.documento, this.telefono, this.nivelRiesgo, 
-        this.fechaNacimiento, this.telefonoFamiliar].some(item => item === '')){
+      if([this.nombres, this.apellidos, this.direccion, this.correo, this.tipoDocumento, this.documento, this.telefono, this.nivelRiesgo,
+        this.fechaNacimiento, this.telefonoFamiliar].some(item => item === '')) {
           this.mostrarCamposVacios=true;
-        }else{
+        } else {
           this.ocultar=!this.ocultar;
         }
     }

--- a/src/views/Trabajadores.vue
+++ b/src/views/Trabajadores.vue
@@ -34,7 +34,7 @@
                 <input type="text" v-model="direccion" class="form-control" id="direccion" placeholder="Dirección actual" required />
                 </div>
                 <div class="form-group">
-                <input type="text" v-model="correo" class="form-control" pattern="[a-z0-9_ñ._%+-]+@[a-z0-9_ñ.-]+\.[a-z]{2,}$" id="correo" placeholder="Correo" required/>
+                <input type="email" v-model="correo" class="form-control" id="correo" placeholder="Correo" required/>
                 </div>
               <div class="form-group">
                 <b-form-select v-model="tipoDocumento" :options="opcionesTipoDoc" required></b-form-select>

--- a/src/views/Trabajadores.vue
+++ b/src/views/Trabajadores.vue
@@ -25,10 +25,10 @@
             <!-- Formulario -->
             <div class="flex-grow-1 overflow-auto py-2 px-0 px-sm-5 my-2">
               <div class="form-group">
-                <input type="text" v-model="nombres" class="form-control" pattern="[A-Za-z_ ]{3,}" id="nombres" placeholder="Nombres" required/>
+                <input type="text" v-model="nombres" class="form-control" pattern="[A-Za-z_ _ñ]{3,}" id="nombres" placeholder="Nombres" required/>
               </div>
               <div class="form-group">
-                <input type="text" v-model="apellidos" class="form-control" pattern="[A-Za-z_ ]{3,}" id="apellidos" placeholder="Apellidos" required/>
+                <input type="text" v-model="apellidos" class="form-control" pattern="[A-Za-z_ _ñ]{3,}" id="apellidos" placeholder="Apellidos" required/>
               </div>
               <div class="form-group">
                 <input type="text" v-model="direccion" class="form-control" id="direccion" placeholder="Dirección actual" required />

--- a/src/views/Trabajadores.vue
+++ b/src/views/Trabajadores.vue
@@ -124,7 +124,7 @@
         <b-button  class="float-left" @click="ocultar = !ocultar" variant="primary" v-show="ocultar">Atras</b-button>
 
         <!-- Botón Registrar -->
-        <b-button  class="float-right" type="submit" variant="primary">Registrar</b-button>
+        <b-button  class="float-right" type="submit" variant="primary" v-if="ocultar">Registrar</b-button>
         </b-form>
       </div>
     </Container>

--- a/src/views/Trabajadores.vue
+++ b/src/views/Trabajadores.vue
@@ -26,10 +26,10 @@
           <!-- Formulario -->
           <div class="flex-grow-1 overflow-auto py-2 px-0 px-sm-5 my-2">
               <div class="form-group">
-                <input type="text" v-model="nombres" class="form-control" id="nombres" placeholder="Nombres" required/>
+                <input type="text" v-model="nombres" class="form-control" pattern="[A-Za-z_ ]{3,}" id="nombres" placeholder="Nombres" required/>
               </div>
               <div class="form-group">
-                <input type="text" v-model="apellidos" class="form-control" id="apellidos" placeholder="Apellidos" required/>
+                <input type="text" v-model="apellidos" class="form-control" pattern="[A-Za-z_ ]{3,}" id="apellidos" placeholder="Apellidos" required/>
               </div>
               <div class="form-group">
                 <input
@@ -86,8 +86,11 @@
                   for="tipoTrabajador"
                 >¿El trabajador se desempeña en el área de salud y seguridad en el trabajo?</label>
               </div>
+            <div v-if="mostrarCamposVacios">
+              <div class="alert alert-danger">Campos vacios</div>
+            </div>
           </div>
-          <b-button class="float-right" @click="ocultar = !ocultar" variant="primary">Siguiente</b-button>
+          <b-button class="float-right" @click="camposVacios()" variant="primary">Siguiente</b-button>
         </div>
 
         <!-- Seleccion de vacunas -->
@@ -116,19 +119,12 @@
             ></b-form-checkbox-group>
             </b-form-group>
         </div>
-        <div v-if="nombres === '' || apellidos === '' || direccion === '' || correo === '' ||
-        tipoDocumento === null || documento === '' || telefono === '' || nivelRiesgo === null ||
-        fechaNacimiento === '' || telefonoFamiliar === ''">
-            <div class="alert alert-danger">Campos vacios</div>
-        </div>
         </div>
         <!-- Botón Atras -->
         <b-button  class="float-left" @click="ocultar = !ocultar" variant="primary" v-show="ocultar">Atras</b-button>
 
         <!-- Botón Registrar -->
-        <b-button  class="float-right" type="submit" variant="primary" v-if="ocultar && !(nombres === '' || apellidos === '' ||
-        direccion === '' || correo === '' || tipoDocumento === null || documento === '' || telefono === '' || nivelRiesgo === null ||
-        fechaNacimiento === '' || telefonoFamiliar === '')">Registrar</b-button>
+        <b-button  class="float-right" type="submit" variant="primary">Registrar</b-button>
         </b-form>
       </div>
     </Container>
@@ -164,6 +160,7 @@ export default {
       detallesVacunacion: [],
       error: {},
       ocultar:false,
+      mostrarCamposVacios:false,
       opcionesRiesgo: [
         {value: null, text: 'Seleccionar nivel de riesgo'},
         {value: 'n1', text: 'I'},
@@ -217,6 +214,15 @@ export default {
       this.tipoTrabajador= '';
       this.detallesVacunacion= [];
       this.ocultar=!this.ocultar;
+      this.mostrarCamposVacios=false;
+    },
+    camposVacios () {
+      if([this.nombres, this.apellidos, this.direccion, this.correo, this.tipoDocumento, this.documento, this.telefono, this.nivelRiesgo, 
+        this.fechaNacimiento, this.telefonoFamiliar].some(item => item === '')){
+          this.mostrarCamposVacios=true;
+        }else{
+          this.ocultar=!this.ocultar;
+        }
     }
   }
 }


### PR DESCRIPTION
Este pull request es para solucionar este error que no me dejaba probaar el registrar trabajadores ni tampoco me mostraba las validaciones de que los campos de nombre solo tuviesen letras 
![image](https://user-images.githubusercontent.com/9545378/67155184-deb3fb00-f2cf-11e9-9faf-409041ad2076.png)

El error era esto https://coderwall.com/p/2qw9za/prevent-an-invalid-form-control-with-name-errors 

Sucedía porque teníamos un formulario para todo el componente del stepper. Cuando le dabamos click en "Siguiente", ese botón por defecto al no tener un type definido se iba como submit e intentaba validar el formulario, pero fallaba, porque al pasar al paso 2 los input que iba a validar estan ocultos y eso causa un error en el navegador
No le podia definir el type=button tampoco a ese boton porque de todas formaas si necesitamos que se valide antes de pasar al siguiente paso
Así que lo que hice fue crear un formulario por paso, también teniendo en cuenta que la info se mantenga.
El error no nos salía a todos porque depende mucho de la versión del navegador.

Ahora si funciona bien 
![image](https://user-images.githubusercontent.com/9545378/67155185-e5427280-f2cf-11e9-9b4d-14ac1b2c75cc.png)

